### PR TITLE
Add a static build option(mac_static) for Mac with GCC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # 1. General Compiler Settings
 #
 CXX       = g++
@@ -17,6 +17,10 @@ endif
 ifeq ($(TARGET),release)      # Mac / Linuxの実行ファイル
 	sources  := $(shell ls src/*.cc)
 	CXXFLAGS += -O3 -DNDEBUG
+endif
+ifeq ($(TARGET),mac_static)      # Mac の静的リンク実行ファイル
+	sources  := $(shell ls src/*.cc)
+	CXXFLAGS += -O3 -DNDEBUG -static-libgcc
 endif
 ifeq ($(TARGET),cluster)      # 疎結合並列探索のマスター側（デバッグ用、assertマクロON）
 	sources  := $(shell ls src/*.cc)
@@ -59,9 +63,9 @@ directories  ?= $(sort $(dir $(objects))) bin
 #
 # 4. Public Targets
 #
-.PHONY: gikou release cluster consultation development profile test coverage run-coverage clean scaffold
+.PHONY: gikou release mac_static cluster consultation development profile test coverage run-coverage clean scaffold
 
-gikou release cluster consultation development profile test coverage:
+gikou release mac_static cluster consultation development profile test coverage:
 	$(MAKE) TARGET=$@ executable
 
 run-coverage: coverage
@@ -79,7 +83,7 @@ scaffold:
 .PHONY: executable
 executable: $(directories) $(objects)
 	$(CXX) $(CXXFLAGS) -o $(output_file) $(objects) $(LIBRARIES)
-	
+
 $(directories):
 	mkdir -p $@
 


### PR DESCRIPTION
Macで静的リンクのビルドをするオプションmac_staticを追加しました。

MacBook Pro 2012のmacOS10.14でgcc4.9を使ってビルドできることを確認しました。
ビルド時に下記の2種類の警告が出ますが、実行イメージは作成され正常に動作することを確認しました。
(動作確認は、GUIで1つの対局の棋譜検討が行えることをmacOS10.13〜macOS10.15で確認しました）

1. コンパイル時の警告
> /var/folders/hp/d07tw3_s5895wz3cthtr55fc0000gn/T//ccvkikIs.s:215:11: warning: section "__textcoal_nt" is deprecated
        .section __TEXT,__textcoal_nt,coalesced,pure_instructions

2. リンク時の警告
> ld: warning: direct access in function 'std::basic_ios<char, std::char_traits<char> >::fill() const' from file '/usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/gcc/x86_64-apple-darwin17.3.0/4.9.4/../../../libstdc++.a(ios-inst.o)' to global weak symbol 'std::ctype<char>::do_widen(char) const' from file 'obj/mac_static/src/gamedb.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings. 